### PR TITLE
Makes the Errors from this crate work on multiple threads

### DIFF
--- a/src/cmd_in.rs
+++ b/src/cmd_in.rs
@@ -1,3 +1,5 @@
+use crate::NasusResult;
+
 #[derive(Clone, Debug)]
 pub enum CmdIn {
     AuthSuccess {
@@ -29,8 +31,9 @@ pub enum CmdIn {
     Pong,
 }
 
+
 impl CmdIn {
-    pub fn parse(line: String) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn parse(line: String) -> NasusResult<Self> {
         if line.starts_with("PING") {
             return Ok(CmdIn::Ping);
         }


### PR DESCRIPTION
I was trying to do a simple osu! bot, and i noticed that the errors weren't working on multiple threads since they weren't "Send + Sync". And i actually need this use case, so i did some workarounds. But i figured out it would be better to make the errors returned by the library already be "Send + Sync" in the first place. The only changes i made here were changing types.